### PR TITLE
Switched to DoubleMemberAuth

### DIFF
--- a/Tribler/community/doubleentry/community.py
+++ b/Tribler/community/doubleentry/community.py
@@ -64,7 +64,7 @@ class DoubleEntryCommunity(Community):
                     CandidateDestination(),
                     SignaturePayload(),
                     self._generic_timeline_check,
-                    self.on_signature_response)]
+                    self.on_signature)]
 
     def initiate_conversions(self):
         return [DefaultConversion(self), DoubleEntryConversion(self)]

--- a/Tribler/community/doubleentry/community.py
+++ b/Tribler/community/doubleentry/community.py
@@ -75,7 +75,7 @@ class DoubleEntryCommunity(Community):
         """
         self._logger.info("Sending signature request.")
         message = self.create_signature_request_message(candidate)
-        self.dispersy.store_update_forward([message], False, False, True)
+        self.create_signature_request(candidate, message, self.allow_signature_response)
 
     def create_signature_request_message(self, candidate):
         """
@@ -96,9 +96,8 @@ class DoubleEntryCommunity(Community):
         payload = (up, down, total_up, total_down, sequence_number_requester, previous_hash_requester)
         
         meta = self.get_meta_message(SIGNATURE)
-        message = meta.impl(authentication=(self.my_member,),
+        message = meta.impl(authentication=([self.my_member, candidate.get_member], ),
                             distribution=(self.claim_global_time(),),
-                            destination=(candidate,),
                             payload=payload)
         return message
     

--- a/Tribler/community/doubleentry/conversion.py
+++ b/Tribler/community/doubleentry/conversion.py
@@ -10,72 +10,13 @@ class DoubleEntryConversion(BinaryConversion):
     """
 
     def __init__(self, community):
-        super(DoubleEntryConversion, self).__init__(community, "\x01")
-        from Tribler.community.doubleentry.community import SIGNATURE_REQUEST
-        from Tribler.community.doubleentry.community import SIGNATURE_RESPONSE
+        super(DoubleEntryConversion, self).__init__(community, "\x02")
+        from Tribler.community.doubleentry.community import SIGNATURE
 
-        # Define Request Signature.
-        self.define_meta_message(chr(1), community.get_meta_message(SIGNATURE_REQUEST),
-                                 self._encode_signature_request, self._decode_signature_request)
-        self.define_meta_message(chr(2), community.get_meta_message(SIGNATURE_RESPONSE),
-                                 self._encode_signature_response, self._decode_signature_response)
+        self.define_meta_message(chr(1), community.get_meta_message(SIGNATURE),
+                                 self._encode_signature, self._decode_signature)
 
-    def _encode_signature_request(self, message):
-        """
-        Encode a signature_request message.
-        :param message: The message to be encoded.
-        :return: encoded signature request message.
-        """
-        payload = message.payload
-        return encode((payload.up, payload.down, payload.total_up, payload.total_down,
-                       payload.sequence_number_requester, payload.previous_hash_requester,
-                       payload.public_key_requester, payload.signature_requester)),
-
-    def _decode_signature_request(self, placeholder, offset, data):
-        try:
-            offset, values = decode(data, offset)
-            if len(values) != 8:
-                raise ValueError
-        except ValueError:
-            raise DropPacket("Unable to decode the signature-request")
-
-        up = values[0]
-        if not isinstance(up, int):
-            raise DropPacket("Invalid type up")
-
-        down = values[1]
-        if not isinstance(down, int):
-            raise DropPacket("Invalid type down")
-
-        total_up = values[2]
-        if not isinstance(total_up, int):
-            raise DropPacket("Invalid type total_up")
-
-        total_down = values[3]
-        if not isinstance(total_down, int):
-            raise DropPacket("Invalid type total_down")
-
-        sequence_number_requester = values[4]
-        if not isinstance(sequence_number_requester, int):
-            raise DropPacket("Invalid type sequence_number_requester")
-
-        previous_hash_requester = values[5]
-        if not isinstance(previous_hash_requester, str):
-            raise DropPacket("invalid type previous hash")
-
-        public_key_requester = values[6]
-        if not isinstance(public_key_requester, str):
-            raise DropPacket("Invalid public_key")
-
-        signature_requester = values[7]
-        if not isinstance(signature_requester, str):
-            raise DropPacket("Invalid type signature_request")
-
-        return offset, placeholder.meta.\
-            payload.implement(up, down, total_up, total_down, sequence_number_requester,
-                              previous_hash_requester, public_key_requester, signature_requester)
-
-    def _encode_signature_response(self, message):
+    def _encode_signature(self, message):
         # Encode a tuple containing the timestamp, the signature of the requester and the responder.
         # Return (encoding,)
         payload = message.payload
@@ -84,7 +25,7 @@ class DoubleEntryConversion(BinaryConversion):
                        payload.public_key_requester, payload.signature_requester, payload.sequence_number_responder,
                        payload.previous_hash_responder, payload.public_key_responder, payload.signature_responder)),
 
-    def _decode_signature_response(self, placeholder, offset, data):
+    def _decode_signature(self, placeholder, offset, data):
         try:
             offset, values = decode(data, offset)
             if len(values) != 12:

--- a/Tribler/community/doubleentry/payload.py
+++ b/Tribler/community/doubleentry/payload.py
@@ -1,68 +1,6 @@
 from Tribler.dispersy.payload import Payload
 
-
-class SignatureRequestPayload(Payload):
-    """
-    Payload for message to Request Signing a TimeStamp.
-    """
-
-    class Implementation(Payload.Implementation):
-        def __init__(self, meta, up, down, total_up, total_down,
-                     sequence_number_requester, previous_hash, public_key, signature):
-            """
-            Creates the payload taking the timestamp from the system clock.
-            """
-            super(SignatureRequestPayload.Implementation, self).__init__(meta)
-
-            self._up = up
-            self._down = down
-            self._total_up = total_up
-            self._total_down = total_down
-
-            self._sequence_number_requester = sequence_number_requester
-            self._previous_hash_requester = previous_hash
-            self._public_key_requester = public_key
-            self._signature_requester = signature
-
-        @property
-        def up(self):
-            return self._up
-
-        @property
-        def down(self):
-            return self._down
-
-        @property
-        def total_up(self):
-            return self._total_up
-
-        @property
-        def total_down(self):
-            return self._total_down
-
-        @property
-        def sequence_number_requester(self):
-            return self._sequence_number_requester
-
-        @property
-        def previous_hash_requester(self):
-            return self._previous_hash_requester
-
-        @property
-        def public_key_requester(self):
-            return self._public_key_requester
-
-        @property
-        def signature_requester(self):
-            return self._signature_requester
-
-        def signature_data_requester(self):
-            return encode_signing_format(
-                (self._up, self._down, self.total_up, self.total_down, self._sequence_number_requester,
-                 self.previous_hash_requester, self._public_key_requester))
-
-
-class SignatureResponsePayload(Payload):
+class SignaturePayload(Payload):
     """
     Payload for message that will respond to a Signature Request containing
     the Signature of {timestamp,signature_requester}.
@@ -70,28 +8,26 @@ class SignatureResponsePayload(Payload):
 
     class Implementation(Payload.Implementation):
         def __init__(self, meta, up, down, total_up, total_down, sequence_number_requester,
-                     previous_hash_requester, public_key_requester, signature_requester,
-                     sequence_number_responder, previous_hash_responder, public_key_responder, signature_responder):
+                     previous_hash_requester, sequence_number_responder=-1, previous_hash_responder=''):
             """
             Creates the payload containing the signature of {timestamp,signature_requester}
             by the recipient of the SignatureRequest.
             """
-            super(SignatureResponsePayload.Implementation, self).__init__(meta)
+            super(SignaturePayload.Implementation, self).__init__(meta)
+            #TODO: snorberhuis add asserts here to do some type checking
 
             self._up = up
             self._down = down
             self._total_up = total_up
             self._total_down = total_down
+            
             """ Set the partial signature of the requester in the payload of the message."""
             self._sequence_number_requester = sequence_number_requester
             self._previous_hash_requester = previous_hash_requester
-            self._public_key_requester = public_key_requester
-            self._signature_requester = signature_requester
+            
             """ Set the partial signature of the responder in the payload of the message."""
             self._sequence_number_responder = sequence_number_responder
             self._previous_hash_responder = previous_hash_responder
-            self._public_key_responder = public_key_responder
-            self._signature_responder = signature_responder
 
         @property
         def up(self):
@@ -116,14 +52,6 @@ class SignatureResponsePayload(Payload):
         @property
         def previous_hash_requester(self):
             return self._previous_hash_requester
-
-        @property
-        def public_key_requester(self):
-            return self._public_key_requester
-
-        @property
-        def signature_requester(self):
-            return self._signature_requester
 
         @property
         def sequence_number_responder(self):
@@ -132,31 +60,3 @@ class SignatureResponsePayload(Payload):
         @property
         def previous_hash_responder(self):
             return self._previous_hash_responder
-
-        @property
-        def public_key_responder(self):
-            return self._public_key_responder
-
-        @property
-        def signature_responder(self):
-            return self._signature_responder
-
-        def signature_data_requester(self):
-            return encode_signing_format(
-                (self._up, self._down, self.total_up, self.total_down, self.sequence_number_requester,
-                 self.previous_hash_requester, self._public_key_requester))
-
-        def signature_data_responder(self):
-            return encode_signing_format(
-                (self._up, self._down, self.total_up, self.total_down, self._sequence_number_requester,
-                 self.previous_hash_requester, self._public_key_requester, self.signature_requester,
-                 self._sequence_number_responder, self._previous_hash_responder, self._public_key_responder))
-
-
-def encode_signing_format(data):
-    """
-    Prepare a iterable for singing.
-    :param data: Iterable with objects transformable to string
-    :return: string to be signed containing the data.
-    """
-    return ".".join(map(str, data))


### PR DESCRIPTION
Probably not working but it should be close.

Needs a newer version of Dispersy, update the pointer when
https://github.com/Tribler/dispersy/pull/432 is merged.

Basically, the signatures of both peers are now in the authentication layer instead of in the packet.
If you have any questions feel free to contact me.
